### PR TITLE
Issue #31: Preventing creation of group with same name as existing group

### DIFF
--- a/routes/group.js
+++ b/routes/group.js
@@ -1,7 +1,7 @@
 var Group = require(APP_ROOT + '/models/group');
 var User = require(APP_ROOT + '/models/user');
 var express = require('express');
-var utils = require(APP_ROOT + '/utils/utils');
+utils = require(APP_ROOT + '/utils/utils');
 var async = require('async');
 var router = express.Router();
 

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -6,13 +6,22 @@ module.exports = {
 
     return dir;
   },
+
   // route middleware to make sure a user is logged in
   isLoggedIn: function(req, res, next) {
-    // if user is authenticated in the session, carry on 
+    // if user is authenticated in the session, carry on
     if (req.isAuthenticated())
       return next();
 
     // if they aren't redirect them to the home page
     res.redirect('/');
+  },
+
+  // Normalizing strings to account for case and punctuation
+  normalizeName: function(rawString) {
+    var lowerCased = rawString.toLowerCase(),
+        noPunc = lowerCased.replace(/[\.,-\/#!$%\^&\*;:{}=\-_`~()@\'?]/g,""),
+        cleanedUp = noPunc.replace(/\s{2,}/g," ");
+    return cleanedUp;
   }
 };

--- a/views/error.html
+++ b/views/error.html
@@ -6,7 +6,11 @@
     <h1><span class="fa fa-lock"></span> {{ title }} </h1>
 
     <p>Oops, that page isn't available!</p>
-    
+
+    {% if errorMsg %}
+        <p> Error: {{ errorMsg }}</p>
+    {% endif %}
+
     {% if auth %}
       <a href="/" class="btn btn-default btn-sm"> Home</a>
     {% else %}


### PR DESCRIPTION
So this is a really dumb way of doing it: when a user tries to create a group, we'll query for all existing groups, and compare the 'normalized' names to the proposed new group's name.

Originally I wanted to add a migration to the Groups table to include a column for 'normalizedName', but I couldn't figure out how to get migrations to work with sequelize :( I was trying to follow the instructions on [here](http://sequelizejs.com/docs/latest/migrations), but it was trying to migrate mySql instead of postgres? If somebody can point me to an example of sequelize migrations with postgres, happy to implement that instead.

Also, importing utils with `var utils = require(APP_ROOT + '/utils/utils');` in group.js didn't give me access to `utils` in the router. I'm guessing it's a scope problem (damn javascript), but taking away the `var` made it work...so yea. @yjkogan can tell me if I've done something horrible.

@danielsuo and @yjkogan please review?
